### PR TITLE
Update dev dependencies

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -8,14 +8,14 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "browser-sync": "^2.15.0",
-    "del": "^2.2.2",
+    "browser-sync": "^2.18.13",
+    "del": "^3.0.0",
     "gulp": "^3.9.1",
-    "gulp-composer": "^0.4.0",
-    "gulp-zip": "^3.2.0",
-    "joomla-gulp": "^1.1.1",
-    "require-dir": "^0.3.0",
-    "xml2js": "^0.4.17"
+    "gulp-composer": "^0.4.4",
+    "gulp-zip": "^4.0.0",
+    "joomla-gulp": "^1.1.3",
+    "require-dir": "^0.3.2",
+    "xml2js": "^0.4.19"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Update the dev dependencies to their latest versions

`del` and `gulp-zip` are both by the same author and are only major updates as they've dropped support for Node.js 0.10 and 0.12