### PR TITLE
Fix doc title to joomla-twig

### DIFF
--- a/docs/_data/sidebar.yml
+++ b/docs/_data/sidebar.yml
@@ -1,6 +1,6 @@
 - title: Introduction
   links: 
-    - title: About joomla-git
+    - title: About joomla-twig
       url: /
 - title: Global variables
   links: 


### PR DESCRIPTION
Looks like there was a typo in the docs ;)
![image](https://user-images.githubusercontent.com/2596554/32907470-68636e66-cb00-11e7-88a3-7dfb1a133f96.png)
