### PR TITLE
Fail retrieving updates xml file

### DIFF
--- a/extensions/pkg_twig.xml
+++ b/extensions/pkg_twig.xml
@@ -40,6 +40,6 @@
 		<file type="plugin" id="unserialize" group="twig" enabled="true">plugins/twig/unserialize</file>
 	</files>
 	<updateservers>
-		<server type="extension" name="Joomla Twig Update Site">https://raw.githubusercontent.com/phproberto/joomla-twig/tree/master/updates/twig_update.xml</server>
+		<server type="extension" name="Joomla Twig Update Site">https://raw.githubusercontent.com/phproberto/joomla-twig/master/updates/twig_update.xml</server>
 	</updateservers>
 </extension>


### PR DESCRIPTION
When testing https://github.com/phproberto/joomla-twig/pull/34 I used a local url. After merging it I tested again against github's xml file and it fails:

`Update: Could not open update site #5 "Joomla Twig Update Site", URL: https://raw.githubusercontent.com/phproberto/joomla-twig/tree/master/updates/twig_update.xml`