### PR TITLE
php7 type hints

### DIFF
--- a/extensions/libraries/twig/src/Extension/JArray.php
+++ b/extensions/libraries/twig/src/Extension/JArray.php
@@ -26,7 +26,7 @@ final class JArray extends AbstractExtension
 	 *
 	 * @return  array
 	 */
-	public function getFilters()
+	public function getFilters() : array
 	{
 		return [
 			new TwigFilter('to_array', [$this, 'toArray'])
@@ -40,7 +40,7 @@ final class JArray extends AbstractExtension
 	 *
 	 * @return  array
 	 */
-	public function toArray($var)
+	public function toArray($var) : array
 	{
 		return (array) ($var);
 	}
@@ -50,7 +50,7 @@ final class JArray extends AbstractExtension
 	 *
 	 * @return  string
 	 */
-	public function getName()
+	public function getName() : string
 	{
 		return 'jarray';
 	}

--- a/extensions/libraries/twig/src/Extension/JHtml.php
+++ b/extensions/libraries/twig/src/Extension/JHtml.php
@@ -27,7 +27,7 @@ final class JHtml extends AbstractExtension
 	 *
 	 * @return  array
 	 */
-	public function getFunctions()
+	public function getFunctions() : array
 	{
 		$options = [
 			'is_safe' => ['html']
@@ -43,7 +43,7 @@ final class JHtml extends AbstractExtension
 	 *
 	 * @return  string
 	 */
-	public function getName()
+	public function getName() : string
 	{
 		return 'jhtml';
 	}

--- a/extensions/libraries/twig/src/Extension/JLanguage.php
+++ b/extensions/libraries/twig/src/Extension/JLanguage.php
@@ -27,7 +27,7 @@ final class JLanguage extends AbstractExtension
 	 *
 	 * @return  array
 	 */
-	public function getFunctions()
+	public function getFunctions() : array
 	{
 		return [
 			new TwigFunction('jlang', [Language::class, 'getInstance'])
@@ -39,7 +39,7 @@ final class JLanguage extends AbstractExtension
 	 *
 	 * @return  string
 	 */
-	public function getName()
+	public function getName() : string
 	{
 		return 'jlang';
 	}

--- a/extensions/libraries/twig/src/Extension/JLayout.php
+++ b/extensions/libraries/twig/src/Extension/JLayout.php
@@ -28,7 +28,7 @@ final class JLayout extends AbstractExtension
 	 *
 	 * @return  array
 	 */
-	public function getFunctions()
+	public function getFunctions() : array
 	{
 		$options = [
 			'is_safe' => ['html']
@@ -46,7 +46,7 @@ final class JLayout extends AbstractExtension
 	 *
 	 * @return  FileLayout
 	 */
-	public function getFileLayout()
+	public function getFileLayout() : FileLayout
 	{
 		$class = new \ReflectionClass(FileLayout::class);
 
@@ -58,7 +58,7 @@ final class JLayout extends AbstractExtension
 	 *
 	 * @return  string
 	 */
-	public function getName()
+	public function getName() : string
 	{
 		return 'jlayout';
 	}

--- a/extensions/libraries/twig/src/Extension/JPosition.php
+++ b/extensions/libraries/twig/src/Extension/JPosition.php
@@ -29,7 +29,7 @@ final class JPosition extends AbstractExtension
 	 *
 	 * @return  array
 	 */
-	public function getFunctions()
+	public function getFunctions() : array
 	{
 		$options = [
 			'is_safe' => ['html']
@@ -48,7 +48,7 @@ final class JPosition extends AbstractExtension
 	 *
 	 * @return  string
 	 */
-	public function render($position, $attribs = [])
+	public function render(string $position, array $attribs = []) : string
 	{
 		$modules  = $this->getModules($position);
 		$renderer = $this->getModuleRenderer();
@@ -71,7 +71,7 @@ final class JPosition extends AbstractExtension
 	 *
 	 * @codeCoverageIgnore
 	 */
-	protected function getModules($position)
+	protected function getModules(string $position) : array
 	{
 		return ModuleHelper::getModules($position);
 	}
@@ -83,7 +83,7 @@ final class JPosition extends AbstractExtension
 	 *
 	 * @codeCoverageIgnore
 	 */
-	protected function getModuleRenderer()
+	protected function getModuleRenderer() : ModuleRenderer
 	{
 		return Factory::getDocument()->loadRenderer('module');
 	}
@@ -93,7 +93,7 @@ final class JPosition extends AbstractExtension
 	 *
 	 * @return  string
 	 */
-	public function getName()
+	public function getName() : string
 	{
 		return 'jposition';
 	}

--- a/extensions/libraries/twig/src/Extension/JProfiler.php
+++ b/extensions/libraries/twig/src/Extension/JProfiler.php
@@ -27,7 +27,7 @@ final class JProfiler extends AbstractExtension
 	 *
 	 * @return  array
 	 */
-	public function getFunctions()
+	public function getFunctions() : array
 	{
 		return [
 			new TwigFunction('jprofiler', [Profiler::class, 'getInstance'])
@@ -39,7 +39,7 @@ final class JProfiler extends AbstractExtension
 	 *
 	 * @return  string
 	 */
-	public function getName()
+	public function getName() : string
 	{
 		return 'jprofiler';
 	}

--- a/extensions/libraries/twig/src/Extension/JRoute.php
+++ b/extensions/libraries/twig/src/Extension/JRoute.php
@@ -27,7 +27,7 @@ final class JRoute extends AbstractExtension
 	 *
 	 * @return  array
 	 */
-	public function getFunctions()
+	public function getFunctions() : array
 	{
 		return [
 			new TwigFunction('jroute', [Route::class, '_']),
@@ -39,7 +39,7 @@ final class JRoute extends AbstractExtension
 	 *
 	 * @return  string
 	 */
-	public function getName()
+	public function getName() : string
 	{
 		return 'jroute';
 	}

--- a/extensions/libraries/twig/src/Extension/JSession.php
+++ b/extensions/libraries/twig/src/Extension/JSession.php
@@ -27,7 +27,7 @@ final class JSession extends AbstractExtension
 	 *
 	 * @return  array
 	 */
-	public function getFunctions()
+	public function getFunctions() : array
 	{
 		return [
 			new TwigFunction('jsession', [Factory::class, 'getSession'])
@@ -39,7 +39,7 @@ final class JSession extends AbstractExtension
 	 *
 	 * @return  string
 	 */
-	public function getName()
+	public function getName() : string
 	{
 		return 'jsession';
 	}

--- a/extensions/libraries/twig/src/Extension/JText.php
+++ b/extensions/libraries/twig/src/Extension/JText.php
@@ -27,7 +27,7 @@ final class JText extends AbstractExtension
 	 *
 	 * @return  array
 	 */
-	public function getFunctions()
+	public function getFunctions() : array
 	{
 		return [
 			new TwigFunction('jtext', [Text::class, '_']),
@@ -40,7 +40,7 @@ final class JText extends AbstractExtension
 	 *
 	 * @return  string
 	 */
-	public function getName()
+	public function getName() : string
 	{
 		return 'jtext';
 	}

--- a/extensions/libraries/twig/src/Extension/JUri.php
+++ b/extensions/libraries/twig/src/Extension/JUri.php
@@ -27,7 +27,7 @@ final class JUri extends AbstractExtension
 	 *
 	 * @return  array
 	 */
-	public function getFunctions()
+	public function getFunctions() : array
 	{
 		return [
 			new TwigFunction('juri', [Uri::class, 'getInstance'])
@@ -39,7 +39,7 @@ final class JUri extends AbstractExtension
 	 *
 	 * @return  string
 	 */
-	public function getName()
+	public function getName() : string
 	{
 		return 'juri';
 	}

--- a/extensions/libraries/twig/src/Extension/JUser.php
+++ b/extensions/libraries/twig/src/Extension/JUser.php
@@ -27,7 +27,7 @@ final class JUser extends AbstractExtension
 	 *
 	 * @return  array
 	 */
-	public function getFunctions()
+	public function getFunctions() : array
 	{
 		return [
 			new TwigFunction('juser', [Factory::class, 'getUser'])
@@ -39,7 +39,7 @@ final class JUser extends AbstractExtension
 	 *
 	 * @return  string
 	 */
-	public function getName()
+	public function getName() : string
 	{
 		return 'juser';
 	}

--- a/extensions/libraries/twig/src/Extension/Unserialize.php
+++ b/extensions/libraries/twig/src/Extension/Unserialize.php
@@ -26,7 +26,7 @@ final class Unserialize extends AbstractExtension
 	 *
 	 * @return  array
 	 */
-	public function getFilters()
+	public function getFilters() : array
 	{
 		return [
 			new TwigFilter('unserialize', 'unserialize')
@@ -38,7 +38,7 @@ final class Unserialize extends AbstractExtension
 	 *
 	 * @return  string
 	 */
-	public function getName()
+	public function getName() : string
 	{
 		return 'junserialize';
 	}

--- a/extensions/libraries/twig/src/Field/LayoutSelector.php
+++ b/extensions/libraries/twig/src/Field/LayoutSelector.php
@@ -50,14 +50,14 @@ abstract class LayoutSelector extends \JFormFieldGroupedList
 	 *
 	 * @return  array  Key: group name. Value: folder
 	 */
-	abstract public function layoutFolders();
+	abstract public function layoutFolders() : array;
 
 	/**
 	 * Get the active frontend template.
 	 *
 	 * @return  string
 	 */
-	protected function activeTemplate()
+	protected function activeTemplate() : string
 	{
 		if (!isset(static::$activeTemplates[$this->clientId]))
 		{
@@ -71,7 +71,7 @@ abstract class LayoutSelector extends \JFormFieldGroupedList
 
 			$db->setQuery($query);
 
-			static::$activeTemplates[$this->clientId] = $db->loadResult();
+			static::$activeTemplates[$this->clientId] = (string) $db->loadResult();
 		}
 
 		return static::$activeTemplates[$this->clientId];
@@ -82,7 +82,7 @@ abstract class LayoutSelector extends \JFormFieldGroupedList
 	 *
 	 * @return  string
 	 */
-	protected function cacheHash()
+	protected function cacheHash() : string
 	{
 		return md5($this->type . '|' . $this->clientId);
 	}
@@ -113,7 +113,7 @@ abstract class LayoutSelector extends \JFormFieldGroupedList
 	 *
 	 * @return  array
 	 */
-	protected function folderLayouts($folder)
+	protected function folderLayouts(string $folder) : array
 	{
 		$folder = \JPath::clean($folder);
 
@@ -140,7 +140,7 @@ abstract class LayoutSelector extends \JFormFieldGroupedList
 	 *
 	 * @return  array
 	 */
-	protected function loadGroups()
+	protected function loadGroups() : array
 	{
 		$groups = parent::getGroups();
 		$added = [];

--- a/extensions/libraries/twig/src/Field/ModuleLayout.php
+++ b/extensions/libraries/twig/src/Field/ModuleLayout.php
@@ -39,7 +39,7 @@ final class ModuleLayout extends LayoutSelector
 	 *
 	 * @return  string
 	 */
-	protected function cacheHash()
+	protected function cacheHash() : string
 	{
 		return parent::cacheHash() . md5($this->module);
 	}
@@ -49,7 +49,7 @@ final class ModuleLayout extends LayoutSelector
 	 *
 	 * @return  array
 	 */
-	public function layoutFolders()
+	public function layoutFolders() : array
 	{
 		$appFolder = $this->clientId ? JPATH_ADMINISTRATOR : JPATH_SITE;
 

--- a/extensions/libraries/twig/src/Field/PluginLayout.php
+++ b/extensions/libraries/twig/src/Field/PluginLayout.php
@@ -46,7 +46,7 @@ final class PluginLayout extends LayoutSelector
 	 *
 	 * @return  string
 	 */
-	protected function cacheHash()
+	protected function cacheHash() : string
 	{
 		return parent::cacheHash() . md5($this->pluginGroup . '|' . $this->pluginName);
 	}
@@ -56,7 +56,7 @@ final class PluginLayout extends LayoutSelector
 	 *
 	 * @return  array
 	 */
-	public function layoutFolders()
+	public function layoutFolders() : array
 	{
 		$appFolder = $this->clientId ? JPATH_ADMINISTRATOR : JPATH_SITE;
 

--- a/extensions/libraries/twig/src/Field/ViewLayout.php
+++ b/extensions/libraries/twig/src/Field/ViewLayout.php
@@ -46,7 +46,7 @@ final class ViewLayout extends LayoutSelector
 	 *
 	 * @return  string
 	 */
-	protected function cacheHash()
+	protected function cacheHash() : string
 	{
 		return parent::cacheHash() . md5($this->component . '|' . $this->view);
 	}
@@ -56,7 +56,7 @@ final class ViewLayout extends LayoutSelector
 	 *
 	 * @return  array
 	 */
-	public function layoutFolders()
+	public function layoutFolders() : array
 	{
 		$appFolder = $this->clientId ? JPATH_ADMINISTRATOR : JPATH_SITE;
 

--- a/extensions/libraries/twig/src/Loader/ComponentLoader.php
+++ b/extensions/libraries/twig/src/Loader/ComponentLoader.php
@@ -32,7 +32,7 @@ final class ComponentLoader extends ExtensionLoader
 	 *
 	 * @return  array
 	 */
-	protected function getTemplatePaths()
+	protected function getTemplatePaths() : array
 	{
 		$paths = [];
 
@@ -55,7 +55,7 @@ final class ComponentLoader extends ExtensionLoader
 	 *
 	 * @return  string
 	 */
-	protected function parseExtensionName($name)
+	protected function parseExtensionName(string $name) : string
 	{
 		$nameParts = explode('/', $name);
 

--- a/extensions/libraries/twig/src/Loader/ExtensionLoader.php
+++ b/extensions/libraries/twig/src/Loader/ExtensionLoader.php
@@ -32,7 +32,7 @@ abstract class ExtensionLoader extends \Twig_Loader_Filesystem
 	 *
 	 * @param   string|array  $paths  A path or an array of paths where to look for templates
 	 */
-	public function __construct($paths = [])
+	public function __construct(array $paths = [])
 	{
 		$this->setPaths($this->getTemplatePaths(), $this->extensionNamespace);
 
@@ -44,7 +44,7 @@ abstract class ExtensionLoader extends \Twig_Loader_Filesystem
 	 *
 	 * @return  string
 	 */
-	protected function getBaseAppPath()
+	protected function getBaseAppPath() : string
 	{
 		if (Factory::getApplication()->isAdmin())
 		{
@@ -59,7 +59,7 @@ abstract class ExtensionLoader extends \Twig_Loader_Filesystem
 	 *
 	 * @return  array
 	 */
-	abstract protected function getTemplatePaths();
+	abstract protected function getTemplatePaths() : array;
 
 	/**
 	 * Find a template.
@@ -102,7 +102,7 @@ abstract class ExtensionLoader extends \Twig_Loader_Filesystem
 	 *
 	 * @return  mixed
 	 */
-	protected function findParsedNameTemplate($name)
+	protected function findParsedNameTemplate(string $name)
 	{
 		$parsedName = $this->parseExtensionName($name);
 
@@ -121,7 +121,7 @@ abstract class ExtensionLoader extends \Twig_Loader_Filesystem
 	 *
 	 * @return  boolean
 	 */
-	protected function nameInExtensionNamespace($name)
+	protected function nameInExtensionNamespace(string $name) : bool
 	{
 		$nameParts = explode('/', $name);
 
@@ -135,7 +135,7 @@ abstract class ExtensionLoader extends \Twig_Loader_Filesystem
 	 *
 	 * @return  string
 	 */
-	protected function parseExtensionName($name)
+	protected function parseExtensionName(string $name) : string
 	{
 		return $name;
 	}

--- a/extensions/libraries/twig/src/Loader/LibraryLoader.php
+++ b/extensions/libraries/twig/src/Loader/LibraryLoader.php
@@ -32,7 +32,7 @@ final class LibraryLoader extends ExtensionLoader
 	 *
 	 * @return  array
 	 */
-	protected function getTemplatePaths()
+	protected function getTemplatePaths() : array
 	{
 		$paths = [];
 
@@ -55,7 +55,7 @@ final class LibraryLoader extends ExtensionLoader
 	 *
 	 * @return  string
 	 */
-	protected function parseExtensionName($name)
+	protected function parseExtensionName(string $name) : string
 	{
 		$nameParts = explode('/', $name);
 

--- a/extensions/libraries/twig/src/Loader/ModuleLoader.php
+++ b/extensions/libraries/twig/src/Loader/ModuleLoader.php
@@ -32,7 +32,7 @@ final class ModuleLoader extends ExtensionLoader
 	 *
 	 * @return  array
 	 */
-	protected function getTemplatePaths()
+	protected function getTemplatePaths() : array
 	{
 		$paths = [];
 
@@ -55,7 +55,7 @@ final class ModuleLoader extends ExtensionLoader
 	 *
 	 * @return  string
 	 */
-	protected function parseExtensionName($name)
+	protected function parseExtensionName(string $name) : string
 	{
 		$nameParts = explode('/', $name);
 

--- a/extensions/libraries/twig/src/Loader/PluginLoader.php
+++ b/extensions/libraries/twig/src/Loader/PluginLoader.php
@@ -32,7 +32,7 @@ final class PluginLoader extends ExtensionLoader
 	 *
 	 * @return  array
 	 */
-	protected function getTemplatePaths()
+	protected function getTemplatePaths() : array
 	{
 		$paths = [];
 
@@ -55,7 +55,7 @@ final class PluginLoader extends ExtensionLoader
 	 *
 	 * @return  string
 	 */
-	protected function parseExtensionName($name)
+	protected function parseExtensionName(string $name) : string
 	{
 		$nameParts = explode('/', $name);
 

--- a/extensions/libraries/twig/src/Loader/TemplateLoader.php
+++ b/extensions/libraries/twig/src/Loader/TemplateLoader.php
@@ -32,7 +32,7 @@ final class TemplateLoader extends ExtensionLoader
 	 *
 	 * @return  array
 	 */
-	protected function getTemplatePaths()
+	protected function getTemplatePaths() : array
 	{
 		$paths = [];
 

--- a/extensions/libraries/twig/src/Plugin/BasePlugin.php
+++ b/extensions/libraries/twig/src/Plugin/BasePlugin.php
@@ -32,7 +32,7 @@ abstract class BasePlugin extends CMSPlugin
 	 *
 	 * @return  string
 	 */
-	protected function pluginPath()
+	protected function pluginPath() : string
 	{
 		if (null === $this->pluginPath)
 		{

--- a/extensions/libraries/twig/src/Twig.php
+++ b/extensions/libraries/twig/src/Twig.php
@@ -66,7 +66,7 @@ final class Twig
 	 *
 	 * @return  static
 	 */
-	public static function instance()
+	public static function instance() : Twig
 	{
 		if (null === self::$instance)
 		{
@@ -84,7 +84,7 @@ final class Twig
 	 *
 	 * @return  string
 	 */
-	public static function render($layout, $data = [])
+	public static function render(string $layout, array $data = []) : string
 	{
 		return self::instance()->environment()->render($layout, $data);
 	}
@@ -94,7 +94,7 @@ final class Twig
 	 *
 	 * @return  self
 	 */
-	public function environment()
+	public function environment() : Environment
 	{
 		return $this->environment;
 	}

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -103,6 +103,20 @@ class EnvironmentTest extends \TestCaseDatabase
 	}
 
 	/**
+	 * @test
+	 *
+	 * @return void
+	 */
+	public function triggerReturnsArrayForNonRegisteredEvent()
+	{
+		$loader = new \Twig_Loader_Array;
+		$options = ['sample' => 'option'];
+		$environment = new Environment($loader, $options);
+
+		$this->assertSame([], $environment->trigger('onUnexistingEvent'));
+	}
+
+	/**
 	 * Triggered before environment has been loaded.
 	 *
 	 * @param   Environment      $environment  Loaded environment

--- a/tests/Unit/Field/LayoutSelectorTest.php
+++ b/tests/Unit/Field/LayoutSelectorTest.php
@@ -25,7 +25,7 @@ class LayoutSelectorTest extends BaseLayoutFieldTest
 	 */
 	public function testActiveTemplateReturnsActiveTemplate()
 	{
-		$field = $this->getMockBuilder(SampleField::class)->getMock();
+		$field = new SampleField;
 
 		$reflection = new \ReflectionClass($field);
 		$method = $reflection->getMethod('activeTemplate');
@@ -41,7 +41,7 @@ class LayoutSelectorTest extends BaseLayoutFieldTest
 	 */
 	public function testGetGroupsReturnsCachedData()
 	{
-		$field = $this->getMockBuilder(SampleField::class)->getMock();
+		$field = new SampleField;
 
 		$reflection = new \ReflectionClass($field);
 
@@ -71,13 +71,8 @@ class LayoutSelectorTest extends BaseLayoutFieldTest
 	{
 		$loadedGroups = [5, 6, 7];
 
-		$field = $this->getMockBuilder(SampleField::class)
-			->setMethods(array('loadGroups'))
-			->getMock();
-
-		$field->expects($this->once())
-			->method('loadGroups')
-			->willReturn($loadedGroups);
+		$field = new SampleField;
+		$field->loadGroups = $loadedGroups;
 
 		$reflection = new \ReflectionClass($field);
 
@@ -98,9 +93,7 @@ class LayoutSelectorTest extends BaseLayoutFieldTest
 	 */
 	public function testFolderLayoutsReturnsEmptyArrayForUnexistingFolder()
 	{
-		$field = $this->getMockBuilder(SampleField::class)
-			->setMethods(array('loadGroups'))
-			->getMock();
+		$field = new SampleField;
 
 		$reflection = new \ReflectionClass($field);
 
@@ -117,9 +110,7 @@ class LayoutSelectorTest extends BaseLayoutFieldTest
 	 */
 	public function testFolderLayoutsReturnsLayoutsInExistingFolder()
 	{
-		$field = $this->getMockBuilder(SampleField::class)
-			->setMethods(array('loadGroups'))
-			->getMock();
+		$field = new SampleField;
 
 		$reflection = new \ReflectionClass($field);
 
@@ -141,10 +132,7 @@ class LayoutSelectorTest extends BaseLayoutFieldTest
 	 */
 	public function testLoadGroupsLoadsGroups()
 	{
-		$field = $this->getMockBuilder(SampleField::class)
-			->setMethods(array('cacheHash'))
-			->getMock();
-
+		$field = new SampleField;
 		$reflection = new \ReflectionClass($field);
 
 		$elementProperty = $reflection->getProperty('element');

--- a/tests/Unit/Field/Stubs/SampleField.php
+++ b/tests/Unit/Field/Stubs/SampleField.php
@@ -19,15 +19,32 @@ use Phproberto\Joomla\Twig\Field\LayoutSelector;
 class SampleField extends LayoutSelector
 {
 	/**
+	 * Groups that loadGroups() will return.
+	 *
+	 * @var  array
+	 */
+	public $loadGroups;
+
+	/**
 	 * Get the list of layout folders.
 	 *
 	 * @return  array  Key: group name. Value: folder
 	 */
-	public function layoutFolders()
+	public function layoutFolders() : array
 	{
 		return [
 			'Tests'      => __DIR__ . '/tmpl',
 			'Unexisting' => __DIR__ . '/unexisting'
 		];
+	}
+
+	/**
+	 * Load available option groups
+	 *
+	 * @return  array
+	 */
+	protected function loadGroups() : array
+	{
+		return $this->loadGroups ?: parent::loadGroups();
 	}
 }

--- a/tests/Unit/Loader/ExtensionLoaderTest.php
+++ b/tests/Unit/Loader/ExtensionLoaderTest.php
@@ -175,16 +175,9 @@ class ExtensionLoaderTest extends BaseExtensionLoaderTest
 	public function testFindTemplateReturnsParentFindTemplateIfParsedNameIsDifferentThanSentName()
 	{
 		$name = '@sample-loader/unexisting.html.twig';
-		$parsedName = '@sample-loader/tmpl/unexisting.html.twig';
 
-		$loader = $this->getMockBuilder(SampleLoader::class)
-			->setMethods(array('parseExtensionName'))
-			->getMock();
-
-		$loader->expects($this->once())
-			->method('parseExtensionName')
-			->with($this->equalTo($name))
-			->willReturn($parsedName);
+		$loader = new SampleLoader;
+		$loader->parsedExtensionName = '@sample-loader/tmpl/unexisting.html.twig';
 
 		$reflection = new \ReflectionClass($loader);
 		$method = $reflection->getMethod('findTemplate');

--- a/tests/Unit/Loader/Stubs/SampleLoader.php
+++ b/tests/Unit/Loader/Stubs/SampleLoader.php
@@ -26,14 +26,33 @@ class SampleLoader extends ExtensionLoader
 	protected $extensionNamespace = 'sample-loader';
 
 	/**
+	 * Value that will be returned by parseExtensionName().
+	 *
+	 * @var  string
+	 */
+	public $parsedExtensionName;
+
+	/**
 	 * Get the paths to search for templates.
 	 *
 	 * @return  array
 	 */
-	protected function getTemplatePaths()
+	protected function getTemplatePaths() : array
 	{
 		return [
 			__DIR__ . '/tmpl'
 		];
+	}
+
+	/**
+	 * Parse a received extension name.
+	 *
+	 * @param   string  $name  Name of the template to search
+	 *
+	 * @return  string
+	 */
+	protected function parseExtensionName(string $name) : string
+	{
+		return $this->parsedExtensionName ?: parent::parseExtensionName($name);
 	}
 }


### PR DESCRIPTION
* Ensure that `PluginHelper::importPlugin()` is only called once per importable plugin type tracking already imported plugins.
* Add php7 type hints to:
    * [x] Environment
    * [x] Twig
    * [x] Extensions
    * [x] Fields
    * [x] Loaders
    * [x] BasePlugin
     